### PR TITLE
Added docker-compose for easy boot-up, and reference file for systems integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Video Analytics Serving may be modified to co-exist in a container alongside oth
 (2) Install [docker compose](https://docs.docker.com/compose/install), if you plan to deploy through docker compose. Version 1.20+ is required.
 
 
+### docker-compose
+
+To get started you may either build the service (detailed below), or automatically start it via docker-compose. To use docker-compose, run the following:
+
+```
+docker-compose up
+```
+
+Configuration values can be changed inside the `docker-compose.yml` file to fit your needs.
+
 ### Building
 
 To get started, build the service as a standalone component execute the following command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+    video-analytics-serving:
+        container_name: video-analytics-serving
+        image: video-analytics-serving-gstreamer
+        privileged: true
+        build:
+            context: .
+            dockerfile: docker/Dockerfile
+            args:
+                - noproxy
+                - https_proxy
+                - http_proxy
+                - BASE=video-analytics-serving-gstreamer-base 
+                - FRAMEWORK=gstreamer
+                - MODELS_PATH=models
+                - PIPELINES_PATH=pipelines/gstreamer
+                - PIPELINES_COMMAND=copy_pipelines
+        ports:
+            - "8080:8080"
+        devices:
+            - /dev/dri:/dev/dri


### PR DESCRIPTION
EDIT: On further test, this actually fails because of some dependencies that are not possible to write over to a `docker-compose.yml` file. I instead resolved issue by creating a `Makefile` that first makes the container before running within `docker-compose`.

---
As detailed in title, `docker-compose.yml` file was added to the root directory of the project to allow the Docker Compose utility to automatically boot-up the service without `build.sh` and `run.sh`. 

Useful as a reference file for folks who are deploying in the cloud.