### PR TITLE
Enable listing all pipeline status for Video Analytics Serving

### DIFF
--- a/vaserving/pipeline_manager.py
+++ b/vaserving/pipeline_manager.py
@@ -305,6 +305,14 @@ class PipelineManager:
             return self.pipeline_instances[instance_id].params()
         return None
 
+    def get_all_instance_status(self):
+        results = []
+        for key in self.pipeline_instances:
+            tmp = self.pipeline_instances[key].status()
+            tmp['state'] = self.pipeline_instances[key].status()['state'].name
+            results.append(tmp)
+        return json.dumps(results)
+
     def get_instance_status(self, name, version, instance_id):
         if self.instance_exists(name, version, instance_id):
             return self.pipeline_instances[instance_id].status()

--- a/vaserving/rest_api/endpoints.py
+++ b/vaserving/rest_api/endpoints.py
@@ -155,6 +155,22 @@ def pipelines_name_version_instance_id_status_get(name, version, instance_id):  
         logger.error('pipelines_name_version_instance_id_status_get %s', error)
         return ('Unexpected error', HTTPStatus.INTERNAL_SERVER_ERROR)
 
+def pipelines_status_get_all():  # noqa: E501
+    """pipelines_status_get_all
+
+    Returns all instance status summary # noqa: E501
+
+    :rtype: object
+    """
+    try:
+        logger.debug("GET on /pipelines/status_all")
+        result = VAServing.pipeline_manager.get_all_instance_status()
+        if result:
+            return result
+    except Exception as error:
+        logger.error('pipelines_name_version_instance_id_status_get_all %s', error)
+        return ('Unexpected error', HTTPStatus.INTERNAL_SERVER_ERROR)
+
 
 def pipelines_name_version_post(name, version):  # noqa: E501
     """pipelines_name_version_post

--- a/vaserving/rest_api/video-analytics-serving.yaml
+++ b/vaserving/rest_api/video-analytics-serving.yaml
@@ -189,6 +189,18 @@ paths:
                 $ref: '#/components/schemas/PipelineInstanceStatus'
           description: Success
       x-openapi-router-controller: vaserving.rest_api.endpoints
+  /pipelines/status_all:
+    get:
+      description: Returns all pipeline instance status.
+      operationId: pipelines_status_get_all
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PipelineInstanceStatus'
+          description: Success
+      x-openapi-router-controller: vaserving.rest_api.endpoints
 components:
   schemas:
     AnyValue: {}


### PR DESCRIPTION
This commit enables a new REST API endpoints which provides users capability to list all pipelines rather than querying each pipelines ID individually using RESTful endpoints. This also lists all pipelines status directly from GST States.

New RESTful API endpoint:
```
curl http://localhost:8080/pipelines/status_all
```

Sample output:
Before prettify:
```
"[{\"id\": 1, \"state\": \"COMPLETED\", \"avg_fps\": 8.932587737800183, \"start_time\": 1638179813.2005367, \"elapsed_time\": 72.43142008781433, \"avg_pipeline_latency\": 0.4533823041311556}, {\"id\": 2, \"state\": \"ERROR\", \"avg_fps\": 0, \"start_time\": null, \"elapsed_time\": null}, {\"id\": 3, \"state\": \"RUNNING\", \"avg_fps\": 6.366260838099841, \"start_time\": 1638179886.3203313, \"elapsed_time\": 16.493194580078125, \"avg_pipeline_latency\": 0.6517487730298723}, {\"id\": 4, \"state\": \"RUNNING\", \"avg_fps\": 3.820389946226454, \"start_time\": 1638179896.0079544, \"elapsed_time\": 6.805586099624634, \"avg_pipeline_latency\": 1.0616143116584191}, {\"id\": 5, \"state\": \"QUEUED\", \"avg_fps\": 0.0, \"start_time\": 1638179899.0670815, \"elapsed_time\": 3.7464776039123535}]"
```

After prettify:
```
[
  {
    "id": 1,
    "state": "COMPLETED",
    "avg_fps": 8.932587737800183,
    "start_time": 1638179813.2005367,
    "elapsed_time": 72.43142008781433,
    "avg_pipeline_latency": 0.4533823041311556
  },
  {
    "id": 2,
    "state": "ERROR",
    "avg_fps": 0,
    "start_time": null,
    "elapsed_time": null
  },
  {
    "id": 3,
    "state": "RUNNING",
    "avg_fps": 6.366260838099841,
    "start_time": 1638179886.3203313,
    "elapsed_time": 16.493194580078125,
    "avg_pipeline_latency": 0.6517487730298723
  },
  {
    "id": 4,
    "state": "RUNNING",
    "avg_fps": 3.820389946226454,
    "start_time": 1638179896.0079544,
    "elapsed_time": 6.805586099624634,
    "avg_pipeline_latency": 1.0616143116584191
  },
  {
    "id": 5,
    "state": "QUEUED",
    "avg_fps": 0,
    "start_time": 1638179899.0670815,
    "elapsed_time": 3.7464776039123535
  }
]
```

Signed-off-by: Stanley Phoong Cheong Kwan <stanley.cheong.kwan.phoong@intel.com>